### PR TITLE
Add better logging

### DIFF
--- a/client/sflvault/client/client.py
+++ b/client/sflvault/client/client.py
@@ -901,7 +901,11 @@ class SFLvaultClient(object):
 
     @authenticate(True)
     def service_get_tree(self, service_id, with_groups=False):
-        """Get information to be edited"""
+        """Get information to be edited
+
+        :param service_id: Service id
+        :param with_groups: Retrieve groups information (deprecated)
+        """
         return self._service_get_tree(service_id, with_groups)
 
     def _service_get_tree(self, service_id, with_groups=False):
@@ -958,7 +962,13 @@ class SFLvaultClient(object):
 
     @authenticate(True)
     def show(self, service_id, verbose=False, with_groups=False):
-        """Show informations to connect to a particular service"""
+        """Show informations of a service
+
+        :param service_id: Service id
+        :param verbose: Display notes and additional information
+        :param with_groups: Retrieve groups information (deprecated)
+
+        """
         servs = self._service_get_tree(service_id, with_groups)
         self._show(servs, verbose)
 
@@ -977,10 +987,11 @@ class SFLvaultClient(object):
 
             secret = x['plaintext'] if 'plaintext' in x else '[access denied]'
             print "%ss#%d %s" % (pre, x['id'], x['url'])
-            if x['groups_list']:
-                groups = ', '.join(["g#%s %s" % (g[0], g[1])
-                                    for g in x['groups_list']])
-                print "%s%s   groups: %s" % (pre, spc, groups)
+            if verbose:
+                if x['groups_list']:
+                    groups = ', '.join(["g#%s %s" % (g[0], g[1])
+                                        for g in x['groups_list']])
+                    print "%s%s   groups: %s" % (pre, spc, groups)
             print "%s%s   secret: %s" % (pre, spc, secret)
             
             if verbose:

--- a/server/sflvault/lib/vault.py
+++ b/server/sflvault/lib/vault.py
@@ -34,6 +34,7 @@ return clean responses to clean queries.
 
 
 import xmlrpclib
+import json
 
 from sqlalchemy import sql
 from sqlalchemy.exc import InvalidRequestError as InvalidReq
@@ -88,6 +89,40 @@ class SFLvaultAccess(object):
     def log_e(self, msg, data=None):
         self._log_any(log.error, msg, data)
 
+    def log_command(self, command, success=True, **kwargs):
+        """ Log a command as JSON
+
+        Only the command name is mandatory, but log_command can take
+        an arbitrary number of keyword arguments. If no keyword argument
+        is supplied, log_command will produce a log that is of the following
+        format:
+
+        {'command': command_name, 'user_id': user_id, 'username': username,
+         'success' true }
+
+        Where user_id and username are the user_id and user_name of the command
+        issuer.
+
+        If optional arguments are supplied, they will be placed in an
+        "arguments" dictionary.
+
+        If the optional "logger" keyword argument is specified, log_command
+        will use it to log the command. """
+
+        if 'logger' in kwargs:
+            log_command = kwargs['logger']
+        else:
+            log_command = log.info
+
+        command = {
+            'user_id': self.myself_id,
+            'username': self.myself_username,
+            'command': command,
+            'success': success,
+            'arguments': kwargs
+        }
+
+        log_command(json.dumps(command))
     def log_i(self, msg, data=None):
         self._log_any(log.info, msg, data)
 

--- a/server/sflvault/views.py
+++ b/server/sflvault/views.py
@@ -310,7 +310,7 @@ def sflvault_service_get(request, authtok, service_id, group_id=None):
 @xmlrpc_method(endpoint='sflvault', method='sflvault.service_get_tree')
 @authenticated_user
 def sflvault_service_get_tree(request, authtok, service_id, with_groups):
-    return vault.service_get_tree(service_id, with_groups)
+    return vault.service_get_tree(service_id)
 
 @xmlrpc_method(endpoint='sflvault', method='sflvault.service_put')
 @authenticated_user


### PR DESCRIPTION
# Implement better logging

## Introduction
* Following on the discussion in [ticket #3177](https://projects.savoirfairelinux.com/issues/3177) and @spiette's logging recommendations, this ticket aims at implementing an intelligent logging system in SFLvault that will eventually serve as a basis for auditing.

## In general
* This pull request proposes adding a `log_command` function in `vault.py`. This `log_command` function may take any argument and will output it to JSON.

* The output is JSON, meaning that it can be easily picked up by a log indexing solution such as logstash.

## What exactly is logged?
All commands that have an effect on the database are logged. More precisely, here are the logged commands with a sample log message:

Command | Message
--------------|------------
 `customer-add` | `{"username": "admin", "command": "customer_add", "user_id": 1, "arguments": {"customer_id": 8, "customer_name": "new customer"}, "success": true}`
`customer-del` | `{"username": "admin", "command": "customer_del", "user_id": 1, "arguments": {"customer_id": 8}, "success": true}`
`customer-edit` | `{"username": "admin", "command": "customer_put", "user_id": 1, "arguments": {"customer_id": 7, "data": {"name": "Test name"}}, "success": true}`
`group-add` | `{"username": "admin", "user_id": 1, "success": true, "command": "customer_put", "arguments": {"customer_id": 1, "data": {"name": "sdfdsfsd"}}}`
`group-add-service` | `{"username": "admin", "command": "group_add_service", "user_id": 1, "arguments": {"service_id": 1, "group_id": 2}, "success": true}`
`group-del-service` | `{"username": "admin", "command": "group_del_service", "user_id": 1, "arguments": {"service_id": 1, "group_id": 2}, "success": true}`
`group-add-user` | `{"username": "admin", "command": "group_add_user", "user_id": 1, "arguments": {"group_id": 2, "user_id": 2}, "success": true}`
`group-del-user` | `{"username": "admin", "command": "group_del_user", "user_id": 1, "arguments": {"group_id": 2, "user_id": 2}, "success": true}`
`group-edit` | `{"username": "admin", "command": "group_put", "user_id": 1, "arguments": {"group_id": 2, "data": {"name": "New group name"}}, "success": true}`
`machine-add` | `{"username": "admin", "command": "machine_add", "user_id": 1, "arguments": {"machine_id": 21}, "success": true}`
`machine-del` | `{"username": "admin", "command": "machine_del", "user_id": 1, "arguments": {"machine_id": 3}, "success": true}`
`machine-edit` | `{"username": "admin", "command": "machine_put", "user_id": 1, "arguments": {"machine_id": 21, "data": {"name": "test name", "ip": "test ip", "notes": "test notes", "fqdn": "test fqdn", "location": "test location", "customer_id": "2"}}, "success": true}`
`service-add` | `{"username": "admin", "command": "service_add", "user_id": 1, "arguments": {"service_id": 2}, "success": true}`
`service-del` | `{"username": "admin", "command": "service_del", "user_id": 1, "arguments": {"service_id": 2}, "success": true}`
`service-edit` | `{"username": "admin", "command": "service_put", "user_id": 1, "arguments": {"service_id": 2, "data": {"machine_id": "2", "parent_service_id": "1", "metadata": {"a": "2", "b": "3"}}}, "success": true}`
`service-passwd` | `{"username": "admin", "command": "service_passwd", "user_id": 1, "arguments": {"service_id": 2}, "success": true}`
`user-add` | `{"username": "admin", "command": "user_add", "user_id": 1, "arguments": {"username": "david", "new_user_id": 4, "is_admin": false}, "success": true}`
`user-del` | `{"username": "admin", "command": "user_del", "user_id": 1, "arguments": {"username": "david"}, "success": true}`
`user-setup` | `{"username": "admin", "command": "user_setup", "user_id": 1, "arguments": {"username": "david"}, "success": true}`
*Please see [1]*
The following immutable commands are of crucial importance for anyone willing to use the logs to perform an audit and are also logged:

Command | Message
--------------|------------
`show` and `connect` | `{"username": "admin", "command": "show", "user_id": 1, "arguments": {"service_ids": [1, 2]}, "success": true}`

You will notice that `show` now returns two lists of service_ids. Here is their descriptions:

Option | Description
---------|---------------
`all_service_ids` | All the service ids returned by show, regardless of the ability of the possibility of the users to see them.
`accessible_service_ids` | The services that the user should be able to see given the group he's in.

The reason we make this distintion is because SFLvault sends the secret to the user regardless of the groups he's in.  Maybe this shouldn't be happening, and the server should only send secrets to "legitimate" users. I think we should eventually fix this, but this should be part of another PR.

## Notes
1. The log message for `user-setup` should read `{ "username": "None", "user_id":"None" }`. This is a separate issue. (See #14)
