### PR TITLE
Enh proper ssl certificate bypass

### DIFF
--- a/client/CHANGES.txt
+++ b/client/CHANGES.txt
@@ -12,3 +12,4 @@ SFLVault Client Release Notes
 * Fix namespace packaging issue.
 * Fix compatibility with newer python-keyring versions. (#44977)
 * Merged with SFLvault-common.
+* Add support to disable the "strong" SSL certificate verification process.

--- a/client/sflvault/client/client.py
+++ b/client/sflvault/client/client.py
@@ -432,7 +432,7 @@ class SFLvaultClient(object):
         # Set the default route to the Vault
         url = self.cfg.get('SFLvault', 'url')
         if url:
-            self.vault = xmlrpclib.Server(url, allow_none=True).sflvault
+            self._set_vault(url)
 
     def set_getpassfunc(self, func=None):
         """Set the function to ask for passphrase.

--- a/client/sflvault/client/client.py
+++ b/client/sflvault/client/client.py
@@ -25,6 +25,8 @@ import sys
 import re
 import os
 import time
+import warnings
+import ssl
 
 from subprocess import Popen, PIPE
 
@@ -448,7 +450,14 @@ class SFLvaultClient(object):
         
     def _set_vault(self, url, save=False):
         """Set the vault's URL and optionally save it"""
-        self.vault = xmlrpclib.Server(url, allow_none=True).sflvault
+        suppl_kw = {}
+        if (self.cfg.has_option('SFLvault', 'allow-unverified-ssl-context')
+                and '1' == self.cfg.get('SFLvault', 'allow-unverified-ssl-context')):
+            if sys.version_info[:3] >= (2, 7, 9):
+                suppl_kw['context'] = ssl._create_unverified_context()
+            else:
+                warnings.warn('allow-unverified-ssl-context has only meaning for Python >= 2.7.9')
+        self.vault = xmlrpclib.Server(url, allow_none=True, **suppl_kw).sflvault
         if save:
             self.cfg.set('SFLvault', 'url', url)
 

--- a/docs/sphinxsrc/install.rst
+++ b/docs/sphinxsrc/install.rst
@@ -116,6 +116,14 @@ To provide a configuration file to your SFLvault instance, please use the follow
    sflvault.keyfile = /path/to/ssl/keyfile
    sflvault.certfile = /path/to/ssl/certfile
 
+   # BEGIN SSL note:
+
+   # sflvault.allow-unverified-ssl-context = 1
+
+   # If you happen to use a self-signed server certificate and you have Python >= 2.7.9
+   # then you'll need to enable this option.
+   # END SSL note.
+
    # Logging configuration
    [loggers]
    keys = root, sflvault, sqlalchemy
@@ -283,6 +291,11 @@ Section sflvault
   Paths to a key file and certificate file to use the SSL mode. When both configurations are set,
   the server is started in SSL mode, otherwise, it's started in plain HTTP mode.
 
+*sflvault.allow-unverified-ssl-context*
+  Determines if a user bypass the server certificate verification.
+  Which can be useful if your server certificate happens to be self-signed.
+  Default value is undefined. Set to '1' to enable the option.
+
 *sqlalchemy.url (default value: sqlite://%(here)s/sflvault.sqlite)*
   Where SFLVault's database is. It's a SQLAlchemy URL, about which you can have more information at
   http://docs.sqlalchemy.org/en/rel_0_8/core/engines.html
@@ -310,6 +323,11 @@ SSL and password safety
 Running the server over SSL is required to ensure password safety. The ``show`` command sends
 passwords in an encrypted form, but ``service-add`` and ``service-passwd`` do not. Someone listening
 to the communications between the client and the server could very easily get these passwords.
+
+In old Python versions (< 2.7.9), the SSL server certificate wasn't strictly validated.
+If you happen to have a self-signed server certificate (or expired) and you run Python >= 2.7.9 then
+you can define sflvault.allow-unverified-ssl-context (to '1') in your configuration file to bypass
+the certificate strict validation.
 
 Make SFLvault a system service
 ==============================

--- a/server/sflvault/lib/vault.py
+++ b/server/sflvault/lib/vault.py
@@ -1264,7 +1264,7 @@ class SFLvaultAccess(object):
         # Delete all related user-ciphers
         query(model.ServiceGroup).filter(model.ServiceGroup.service_id == service_id).delete(synchronize_session=False)
         # Delete the service
-        query(Service).filter(model.Service.id==service_id).delete(synchronize_session=False)
+        query(Service).filter(model.Service.id == service_id).delete(synchronize_session=False)
         transaction.commit()
 
         self.log_command("service_del", service_id=service_id)


### PR DESCRIPTION
Since Python2.7.9 certitficates for SSL are more stricly validated by the ssl code.
This make self-signed certificates to now be rejected by default.
To still allow such certificate we have to provide an option for the user to fallback on the pre-2.7.9 behavior.