### PR TITLE
Give more context when failing because of a malformed IPv6 netloc

### DIFF
--- a/client/sflvault/client/remoting.py
+++ b/client/sflvault/client/remoting.py
@@ -284,9 +284,17 @@ class Chain(object):
         for srv in self.service_list:
             try:
                 srv.prework()
-            except ServiceExpectError, e:
+            except ServiceExpectError as e:
                 # Show error, fall back, and interact to last if it exists.
                 print "[SFLvault] Error connecting to %s: %s" % (srv.data['url'], str(e))
+                break
+            except ValueError as e:
+                # Give additional detail if we receive a ValueError
+                print """ [SFLvault] Error connecting to %s: %s" % (srv.data['url'], str(e))
+There seem to be a problem with the format of the URL of the service
+Please make sure that it is formatted as specified in RFC 3986"
+If your service has an IPv6 address, make sure the IPv6 literal is enclosed in '[' and ']'
+For example: ssh://root@[0:0:0:0:0:0:0:1]:22"""
                 break
             except TypeError, e:
                 print "[SFLvault] Timed out."


### PR DESCRIPTION
It has been reported that SFLvault fails abruptly when trying to connect to a service with an IPv6 address:
1. Let service 1234 have url ssh://root@2607:fad8:4:3:216:3eff:fe18:b490
2. connect 1234

```
File "/usr/bin/sflvault", line 8, in &lt;module&gt;
    load_entry_point('SFLvault==0.7.3dev', 'console_scripts', 'sflvault')()
  File "/usr/lib/python2.5/site-packages/SFLvault-0.7.3dev-py2.5.egg/sflvault/client/client.py", line 880, in main
    s._run()
  File "/usr/lib/python2.5/site-packages/SFLvault-0.7.3dev-py2.5.egg/sflvault/client/client.py", line 103, in run
    runcmd._run(args)
  File "/usr/lib/python2.5/site-packages/SFLvault-0.7.3dev-py2.5.egg/sflvault/client/client.py", line 162, in _run
    getattr(self, action)()
  File "/usr/lib/python2.5/site-packages/SFLvault-0.7.3dev-py2.5.egg/sflvault/client/client.py", line 842, in connect
    self.vault.connect(vid)
  File "&lt;string&gt;", line 1, in &lt;lambda&gt;
  File "/usr/lib/python2.5/site-packages/SFLvault-0.7.3dev-py2.5.egg/sflvault/client/_init__.py", line 132, in do_authenticate
    return func(self, *args, **kwargs)
  File "/usr/lib/python2.5/site-packages/SFLvault-0.7.3dev-py2.5.egg/sflvault/client/__init__.py", line 792, in connect
    connection.connect()
  File "/usr/lib/python2.5/site-packages/SFLvault-0.7.3dev-py2.5.egg/sflvault/client/remoting.py", line 202, in connect
    srv.prework()
  File "/usr/lib/python2.5/site-packages/SFLvault-0.7.3dev-py2.5.egg/sflvault/client/services.py", line 259, in prework
    if self.url.port:
  File "/usr/lib/python2.5/urlparse.py", line 116, in port
    return int(port, 10)
ValueError: invalid literal for int() with base 10: 'fad8:4:3:216:3eff:fe18:b490'
```

However, according to RFC 3986, urls of services that use an IPv6 address should read like this: `ssh://root@[2607:fad8:4:3:216:3eff:fe18:b490]`

This commit fixes this by doing two things:
1. Make sure that SFLvault does not fail abruptly in this case
2. Provide more information and context to the user

Ref RM#2862
