### PR TITLE
Revert "Changed pexpect dependency for pexpect-u"

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -43,7 +43,7 @@ setup(
                       ] + \
                      ([] if platform.system() == 'Windows'
                          else ["urwid>=0.9.8.1",
-                               "pexpect-u>=2.5"]),
+                               "pexpect>=2.3"]),
     packages=find_packages(),
     namespace_packages=['sflvault'],
     include_package_data=True,

--- a/requirements.freeze
+++ b/requirements.freeze
@@ -1,7 +1,7 @@
 SQLAlchemy==0.8.1
 argparse==1.2.1
 decorator==3.4.0
-pexpect-u==2.5.1
+pexpect==2.4
 pycrypto==2.6
 transaction==1.4.1
 urwid==1.1.1


### PR DESCRIPTION
This reverts commit ff1930db425e06f18ac706dedb6affeb1fb52eb9.
PExpect-U is abandoned upstream and its features have been merged back
into PExpect.